### PR TITLE
Add compiled packages to docker

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Download compiled package
         uses: actions/download-artifact@v4
         with:
-          repository: EarthyScience/RQADeforestation.jlöööö
+          github-token: ${{ secrets.GH_PAT }}
+          repository: EarthyScience/RQADeforestation.jl
       - name: debug
         run: ls -l
       - name: Build and push

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           context: ogc-app-cwl
           push: true
-          tags: danlooo/fairsendd:latest, danlooo/fairsendd:${{ github.sha }}, danlooo/fairsendd:${{ github.ref_name }}
+          tags: danlooo/fairsendd:latest, danlooo/fairsendd:${{ github.sha }}
           cache-from: type=registry,ref=danlooo/fairsendd:latest
           cache-to: type=inline

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
     tags: ["*"]
-  pull_request:
   workflow_dispatch:
 jobs:
   build_containers:

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -22,13 +22,10 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Download compiled package
-        uses: actions/download-artifact@v4
+      - name: Download compiled packages
+        run: gh run download --repo EarthyScience/RQADeforestation.jl -n binaries -d ogc-app-cwl/binaries
         with:
-          github-token: ${{ secrets.GH_PAT }}
-          repository: EarthyScience/RQADeforestation.jl
-      - name: debug
-        run: ls -l
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           context: ogc-app-cwl
           push: true
-          tags: danlooo/fairsendd:latest
+          tags: danlooo/fairsendd:latest, danlooo/fairsendd:${{ github.sha }}, danlooo/fairsendd:${{ github.ref_name }}
           cache-from: type=registry,ref=danlooo/fairsendd:latest
           cache-to: type=inline

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download compiled package
         uses: actions/download-artifact@v4
         with:
-          repository: EarthyScience/RQADeforestation.jl
+          repository: EarthyScience/RQADeforestation.jlöööö
       - name: debug
         run: ls -l
       - name: Build and push

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Download compiled packages
         run: gh run download --repo EarthyScience/RQADeforestation.jl -n binaries -d ogc-app-cwl/binaries
-        with:
+        env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download compiled packages
-        run: gh run download --repo EarthyScience/RQADeforestation.jl -n binaries -d ogc-app-cwl/binaries
+        run: gh run download --repo EarthyScience/RQADeforestation.jl --name binaries --dir ogc-app-cwl/binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}
       - name: Build and push

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -22,6 +22,12 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Download compiled package
+        uses: actions/download-artifact@v4
+        with:
+          repository: EarthyScience/RQADeforestation.jl
+      - name: debug
+        run: ls -l
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 etc/nextcloud
+ogc-app-cwl/binaries

--- a/ogc-app-cwl/Dockerfile
+++ b/ogc-app-cwl/Dockerfile
@@ -1,14 +1,5 @@
-FROM julia:1.11.2-bookworm
+FROM debian:bookworm-slim
 WORKDIR /work
-
-ENV JULIA_NUM_THREADS=auto
-
-ENV JULIA_DEPOT_PATH=/.julia
-RUN julia -e 'using Pkg; Pkg.activate("/.julia/environments/v1.11"); Pkg.instantiate(); Pkg.status()'
-COPY Project.toml /.julia/environments/v1.11/
-COPY Manifest.toml /.julia/environments/v1.11/
-RUN julia -e 'using Pkg; Pkg.activate("/.julia/environments/v1.11"); Pkg.instantiate(); Pkg.status()'
-ENV JULIA_DEPOT_PATH=~/.julia:/.julia
-
-ADD run.jl ./
-ENTRYPOINT ["/work/run.jl"]
+COPY binaries/bin /usr/bin
+COPY binaries/lib /usr/lib
+ENTRYPOINT ["RQADeforestation"]


### PR DESCRIPTION
This PR aims to use precompiled versions of RQADeforestation and julia produced by PackageCompiler.jl .
This will reduce startup time by skipping the precompiling step.

### Benchmark
Startup time 
```
time docker run danlooo/fairsendd:a182dee45ca21fd3971af6bd65a336450aa9fc0e --help
```

| commit | time to help command [s] | image size [mB] |
| ---|---| ---|
| a182dee45c | 470 | 1170 |
| c1239930ee |1.348 |513 |


see https://github.com/EarthyScience/RQADeforestation.jl/pull/53
see https://github.com/EarthyScience/RQADeforestation.jl/pull/54
see https://github.com/EarthyScience/RQADeforestation.jl/pull/55